### PR TITLE
fix IQN

### DIFF
--- a/src/experiments/atari.jl
+++ b/src/experiments/atari.jl
@@ -157,7 +157,7 @@ function RLCore.Experiment(
     stop_condition = StopAfterStep(N_TRAINING_STEPS)
 
     description = """
-    This experiment uses alomost the same config in [dopamine](https://github.com/google/dopamine/blob/master/dopamine/agents/dqn/configs/dqn.gin). But do notice that there are some minor differences:
+    This experiment uses almost the same config in [dopamine](https://github.com/google/dopamine/blob/master/dopamine/agents/dqn/configs/dqn.gin). But do notice that there are some minor differences:
 
     - The RMSProp in Flux do not support center option (also the epsilon is not the same).
     - The image resize method used here is provided by ImageTransformers, which is not the same with the one in cv2.


### PR DESCRIPTION
Experiments on pong seem stable now (trained for 6M steps). The expected duration of the whole experiment is 8 days on a Tesla V100-SXM2. Is this fast or slow? (I guess I should compare at some point to rays RLlib).