### PR TITLE
add BasicDQN and DQN experiments with MountainCarEnv

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,18 @@ using Random
                     1 / mean(res.hook[2].times)
             end
 
+            for method in (:BasicDQN, :DQN)
+                res = run(Experiment(
+                    Val(:JuliaRL),
+                    Val(method),
+                    Val(:MountainCar),
+                    nothing;
+                    save_dir = joinpath(dir, string(method))
+                ))
+                @info "stats for $method" avg_reward = mean(res.hook[1].rewards) avg_fps =
+                    1 / mean(res.hook[2].times)
+            end        
+
             for method in (:A2C, :A2CGAE, :PPO)
                 res = run(Experiment(Val(:JuliaRL), Val(method), Val(:CartPole), nothing))
                 @info "stats for $method" avg_reward =


### PR DESCRIPTION
MountainCarEnv is working well but they were no experiments available in the repo with this environment. 

This PR provides two experiments: with BasicDQN and with DQN to solve the MountainCarEnv and the associated tests. This could later be completed with other RLAgents like Rainbow, Prioritized, etc...

Hope this while help !