### PR TITLE
Add GridWorlds.jl environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /Manifest.toml
 /dev/
 **/checkpoints/
+
+# add vim generated temp files
+*~
+*.swp

--- a/Project.toml
+++ b/Project.toml
@@ -46,8 +46,9 @@ julia = "1.4"
 
 [extras]
 OpenSpiel = "ceb70bd2-fe3f-44f0-b81f-41608acaf2f2"
+GridWorlds = "e15a9946-cd7f-4d03-83e2-6c30bacb0043"
 ReinforcementLearningEnvironments = "25e41dd2-4622-11e9-1641-f1adca772921"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ReinforcementLearningEnvironments", "OpenSpiel"]
+test = ["Test", "ReinforcementLearningEnvironments", "OpenSpiel", "GridWorlds"]

--- a/src/ReinforcementLearningZoo.jl
+++ b/src/ReinforcementLearningZoo.jl
@@ -21,8 +21,9 @@ function __init__()
         @require ArcadeLearningEnvironment = "b7f77d8d-088d-5e02-8ac0-89aab2acc977" include("experiments/atari.jl")
         @require SnakeGames = "34dccd9f-48d6-4445-aa0f-8c2e373b5429" include("experiments/snake.jl")
         @require OpenSpiel = "ceb70bd2-fe3f-44f0-b81f-41608acaf2f2" include("experiments/open_spiel.jl")
-        @require GridWorlds = "e15a9946-cd7f-4d03-83e2-6c30bacb0043" include("experiments/gridworlds.jl")
     end
+
+    @require GridWorlds = "e15a9946-cd7f-4d03-83e2-6c30bacb0043" include("experiments/gridworlds.jl")
 end
 
 end # module

--- a/src/ReinforcementLearningZoo.jl
+++ b/src/ReinforcementLearningZoo.jl
@@ -21,6 +21,7 @@ function __init__()
         @require ArcadeLearningEnvironment = "b7f77d8d-088d-5e02-8ac0-89aab2acc977" include("experiments/atari.jl")
         @require SnakeGames = "34dccd9f-48d6-4445-aa0f-8c2e373b5429" include("experiments/snake.jl")
         @require OpenSpiel = "ceb70bd2-fe3f-44f0-b81f-41608acaf2f2" include("experiments/open_spiel.jl")
+        @require GridWorlds = "e15a9946-cd7f-4d03-83e2-6c30bacb0043" include("experiments/gridworlds.jl")
     end
 end
 

--- a/src/experiments/gridworlds.jl
+++ b/src/experiments/gridworlds.jl
@@ -10,7 +10,7 @@ using TensorBoardLogger
 using Logging
 using Random
 
-RLBase.get_state(w::GridWorlds.EmptyGridWorld) = Float64.(vec(GridWorlds.get_agent_view(w)))
+RLBase.get_state(w::GridWorlds.AbstractGridWorld) = Float64.(vec(GridWorlds.get_agent_view(w)))
 
 function RLCore.Experiment(
     ::Val{:JuliaRL},

--- a/src/experiments/gridworlds.jl
+++ b/src/experiments/gridworlds.jl
@@ -95,3 +95,87 @@ function RLCore.Experiment(
 
     Experiment(agent, env, stop_condition, hook, description)
 end
+
+function RLCore.Experiment(
+    ::Val{:JuliaRL},
+    ::Val{:BasicDQN},
+    ::Val{:FourRooms},
+    ::Nothing;
+    save_dir = nothing,
+    seed = 123,
+)
+    if isnothing(save_dir)
+        t = Dates.format(now(), "yyyy_mm_dd_HH_MM_SS")
+        save_dir = joinpath(pwd(), "checkpoints", "JuliaRL_BasicDQN_FourRooms_$(t)")
+    end
+
+    lg = TBLogger(joinpath(save_dir, "tb_log"), min_level = Logging.Info)
+    rng = StableRNG(seed)
+
+    inner_env = GridWorlds.FourRooms()
+
+    integer_actions_wrapper = ActionTransformedEnv(a -> get_actions(inner_env)[a]; mapping = x -> Dict(action => i for (i, action) in enumerate([get_actions(inner_env)...]))[x])
+
+    env = inner_env |> integer_actions_wrapper
+
+    ns, na = length(get_state(env)), length(get_actions(env))
+    agent = Agent(
+        policy = QBasedPolicy(
+            learner = BasicDQNLearner(
+                approximator = NeuralNetworkApproximator(
+                    model = Chain(
+                        Dense(ns, 128, relu; initW = glorot_uniform(rng)),
+                        Dense(128, na; initW = glorot_uniform(rng)),
+                    ) |> cpu,
+                    optimizer = ADAM(),
+                ),
+                batch_size = 32,
+                min_replay_history = 100,
+                loss_func = huber_loss,
+                rng = rng,
+            ),
+            explorer = EpsilonGreedyExplorer(
+                kind = :exp,
+                ϵ_stable = 0.01,
+                decay_steps = 500,
+                rng = rng,
+            ),
+        ),
+        trajectory = CircularCompactSARTSATrajectory(
+            capacity = 1000,
+            reward_type = Float64,
+            state_type = Float64,
+            state_size = (ns,),
+        ),
+    )
+
+    stop_condition = StopAfterStep(1000)
+
+    total_reward_per_episode = TotalRewardPerEpisode()
+    time_per_step = TimePerStep()
+    hook = ComposedHook(
+        total_reward_per_episode,
+        time_per_step,
+        DoEveryNStep() do t, agent, env
+            with_logger(lg) do
+                @info "training" loss = agent.policy.learner.loss
+            end
+        end,
+        DoEveryNEpisode() do t, agent, env
+            with_logger(lg) do
+                @info "training" reward = total_reward_per_episode.rewards[end] log_step_increment =
+                    0
+            end
+        end,
+        DoEveryNStep(10000) do t, agent, env
+            RLCore.save(save_dir, agent)
+            BSON.@save joinpath(save_dir, "stats.bson") total_reward_per_episode time_per_step
+        end,
+    )
+
+    description = """
+    The environment is FourRooms.
+    """
+
+    Experiment(agent, env, stop_condition, hook, description)
+end

--- a/src/experiments/gridworlds.jl
+++ b/src/experiments/gridworlds.jl
@@ -1,0 +1,98 @@
+export Experiment
+
+import .GridWorlds
+using Dates
+using ReinforcementLearningBase
+using ReinforcementLearningCore
+using Flux
+using BSON
+using TensorBoardLogger
+using Logging
+using Random
+
+RLBase.get_state(w::GridWorlds.EmptyGridWorld) = Float64.(vec(GridWorlds.get_agent_view(w)))
+
+function RLCore.Experiment(
+    ::Val{:JuliaRL},
+    ::Val{:BasicDQN},
+    ::Val{:EmptyGridWorld},
+    ::Nothing;
+    save_dir = nothing,
+    seed = 123,
+)
+    if isnothing(save_dir)
+        t = Dates.format(now(), "yyyy_mm_dd_HH_MM_SS")
+        save_dir = joinpath(pwd(), "checkpoints", "JuliaRL_BasicDQN_EmptyGridWorld_$(t)")
+    end
+
+    lg = TBLogger(joinpath(save_dir, "tb_log"), min_level = Logging.Info)
+    rng = StableRNG(seed)
+
+    inner_env = GridWorlds.EmptyGridWorld()
+
+    integer_actions_wrapper = ActionTransformedEnv(a -> get_actions(inner_env)[a]; mapping = x -> Dict(action => i for (i, action) in enumerate([get_actions(inner_env)...]))[x])
+
+    env = inner_env |> integer_actions_wrapper
+
+    ns, na = length(get_state(env)), length(get_actions(env))
+    agent = Agent(
+        policy = QBasedPolicy(
+            learner = BasicDQNLearner(
+                approximator = NeuralNetworkApproximator(
+                    model = Chain(
+                        Dense(ns, 128, relu; initW = glorot_uniform(rng)),
+                        Dense(128, 128, relu; initW = glorot_uniform(rng)),
+                        Dense(128, na; initW = glorot_uniform(rng)),
+                    ) |> cpu,
+                    optimizer = ADAM(),
+                ),
+                batch_size = 32,
+                min_replay_history = 100,
+                loss_func = huber_loss,
+                rng = rng,
+            ),
+            explorer = EpsilonGreedyExplorer(
+                kind = :exp,
+                ϵ_stable = 0.01,
+                decay_steps = 500,
+                rng = rng,
+            ),
+        ),
+        trajectory = CircularCompactSARTSATrajectory(
+            capacity = 1000,
+            reward_type = Float64,
+            state_type = Float64,
+            state_size = (ns,),
+        ),
+    )
+
+    stop_condition = StopAfterStep(10000)
+
+    total_reward_per_episode = TotalRewardPerEpisode()
+    time_per_step = TimePerStep()
+    hook = ComposedHook(
+        total_reward_per_episode,
+        time_per_step,
+        DoEveryNStep() do t, agent, env
+            with_logger(lg) do
+                @info "training" loss = agent.policy.learner.loss
+            end
+        end,
+        DoEveryNEpisode() do t, agent, env
+            with_logger(lg) do
+                @info "training" reward = total_reward_per_episode.rewards[end] log_step_increment =
+                    0
+            end
+        end,
+        DoEveryNStep(10000) do t, agent, env
+            RLCore.save(save_dir, agent)
+            BSON.@save joinpath(save_dir, "stats.bson") total_reward_per_episode time_per_step
+        end,
+    )
+
+    description = """
+    The environment is EmptyGridWorld.
+    """
+
+    Experiment(agent, env, stop_condition, hook, description)
+end

--- a/src/experiments/gridworlds.jl
+++ b/src/experiments/gridworlds.jl
@@ -83,7 +83,7 @@ function RLCore.Experiment(
                     0
             end
         end,
-        DoEveryNStep(10000) do t, agent, env
+        DoEveryNStep(1000) do t, agent, env
             RLCore.save(save_dir, agent)
             BSON.@save joinpath(save_dir, "stats.bson") total_reward_per_episode time_per_step
         end,
@@ -167,7 +167,7 @@ function RLCore.Experiment(
                     0
             end
         end,
-        DoEveryNStep(10000) do t, agent, env
+        DoEveryNStep(1000) do t, agent, env
             RLCore.save(save_dir, agent)
             BSON.@save joinpath(save_dir, "stats.bson") total_reward_per_episode time_per_step
         end,

--- a/src/experiments/gridworlds.jl
+++ b/src/experiments/gridworlds.jl
@@ -179,3 +179,87 @@ function RLCore.Experiment(
 
     Experiment(agent, env, stop_condition, hook, description)
 end
+
+function RLCore.Experiment(
+    ::Val{:JuliaRL},
+    ::Val{:BasicDQN},
+    ::Val{:CollectGems},
+    ::Nothing;
+    save_dir = nothing,
+    seed = 123,
+)
+    if isnothing(save_dir)
+        t = Dates.format(now(), "yyyy_mm_dd_HH_MM_SS")
+        save_dir = joinpath(pwd(), "checkpoints", "JuliaRL_BasicDQN_CollectGems_$(t)")
+    end
+
+    lg = TBLogger(joinpath(save_dir, "tb_log"), min_level = Logging.Info)
+    rng = StableRNG(seed)
+
+    inner_env = GridWorlds.CollectGems()
+
+    integer_actions_wrapper = ActionTransformedEnv(a -> get_actions(inner_env)[a]; mapping = x -> Dict(action => i for (i, action) in enumerate([get_actions(inner_env)...]))[x])
+
+    env = inner_env |> integer_actions_wrapper
+
+    ns, na = length(get_state(env)), length(get_actions(env))
+    agent = Agent(
+        policy = QBasedPolicy(
+            learner = BasicDQNLearner(
+                approximator = NeuralNetworkApproximator(
+                    model = Chain(
+                        Dense(ns, 128, relu; initW = glorot_uniform(rng)),
+                        Dense(128, na; initW = glorot_uniform(rng)),
+                    ) |> cpu,
+                    optimizer = ADAM(),
+                ),
+                batch_size = 32,
+                min_replay_history = 100,
+                loss_func = huber_loss,
+                rng = rng,
+            ),
+            explorer = EpsilonGreedyExplorer(
+                kind = :exp,
+                ϵ_stable = 0.01,
+                decay_steps = 500,
+                rng = rng,
+            ),
+        ),
+        trajectory = CircularCompactSARTSATrajectory(
+            capacity = 1000,
+            reward_type = Float64,
+            state_type = Float64,
+            state_size = (ns,),
+        ),
+    )
+
+    stop_condition = StopAfterStep(1000)
+
+    total_reward_per_episode = TotalRewardPerEpisode()
+    time_per_step = TimePerStep()
+    hook = ComposedHook(
+        total_reward_per_episode,
+        time_per_step,
+        DoEveryNStep() do t, agent, env
+            with_logger(lg) do
+                @info "training" loss = agent.policy.learner.loss
+            end
+        end,
+        DoEveryNEpisode() do t, agent, env
+            with_logger(lg) do
+                @info "training" reward = total_reward_per_episode.rewards[end] log_step_increment =
+                    0
+            end
+        end,
+        DoEveryNStep(1000) do t, agent, env
+            RLCore.save(save_dir, agent)
+            BSON.@save joinpath(save_dir, "stats.bson") total_reward_per_episode time_per_step
+        end,
+    )
+
+    description = """
+    The environment is CollectGems.
+    """
+
+    Experiment(agent, env, stop_condition, hook, description)
+end

--- a/src/experiments/gridworlds.jl
+++ b/src/experiments/gridworlds.jl
@@ -41,7 +41,7 @@ function RLCore.Experiment(
                 approximator = NeuralNetworkApproximator(
                     model = Chain(
                         Dense(ns, 128, relu; initW = glorot_uniform(rng)),
-                        Dense(128, 128, relu; initW = glorot_uniform(rng)),
+                        # Dense(128, 128, relu; initW = glorot_uniform(rng)),
                         Dense(128, na; initW = glorot_uniform(rng)),
                     ) |> cpu,
                     optimizer = ADAM(),
@@ -66,7 +66,7 @@ function RLCore.Experiment(
         ),
     )
 
-    stop_condition = StopAfterStep(10000)
+    stop_condition = StopAfterStep(1000)
 
     total_reward_per_episode = TotalRewardPerEpisode()
     time_per_step = TimePerStep()

--- a/src/experiments/gridworlds.jl
+++ b/src/experiments/gridworlds.jl
@@ -41,7 +41,6 @@ function RLCore.Experiment(
                 approximator = NeuralNetworkApproximator(
                     model = Chain(
                         Dense(ns, 128, relu; initW = glorot_uniform(rng)),
-                        # Dense(128, 128, relu; initW = glorot_uniform(rng)),
                         Dense(128, na; initW = glorot_uniform(rng)),
                     ) |> cpu,
                     optimizer = ADAM(),


### PR DESCRIPTION
Allow addition of environments from the `GridWorlds` package.

Added experiment running `BasicDQN` on `EmptyGridWorld` as an example.

![image](https://user-images.githubusercontent.com/32610387/98121830-d37d3e80-1ed5-11eb-96e0-58120dae75e6.png)