### PR TITLE
DQN: take into account the update_horizon to know if we can update

### DIFF
--- a/src/algorithms/dqns/common.jl
+++ b/src/algorithms/dqns/common.jl
@@ -5,7 +5,7 @@
 const PERLearners = Union{PrioritizedDQNLearner,RainbowLearner,IQNLearner}
 
 function RLBase.update!(learner::Union{DQNLearner,PERLearners}, t::AbstractTrajectory)
-    length(t[:terminal]) < learner.min_replay_history && return
+    length(t[:terminal]) - learner.sampler.n <= learner.min_replay_history && return
 
     learner.update_step += 1
 


### PR DESCRIPTION
Without this change, there can be an update even if the length of the trajectory is not long enough given the update_horizon (and this update triggers an error).