### PR TITLE
Fix ppo pendulum example

### DIFF
--- a/src/experiments/rl_envs/JuliaRL_PPO_Pendulum.jl
+++ b/src/experiments/rl_envs/JuliaRL_PPO_Pendulum.jl
@@ -14,16 +14,16 @@ function RLCore.Experiment(
     lg = TBLogger(joinpath(save_dir, "tb_log"), min_level = Logging.Info)
     rng = StableRNG(seed)
     inner_env = PendulumEnv(T = Float32, rng = rng)
-    action_space = action_space(inner_env)
-    low = action_space.low
-    high = action_space.high
+    A = action_space(inner_env)
+    low = A.left
+    high = A.right
     ns = length(state(inner_env))
 
     N_ENV = 8
     UPDATE_FREQ = 2048
     env = MultiThreadEnv([
         PendulumEnv(T = Float32, rng = StableRNG(hash(seed + i))) |>
-        ActionTransformedEnv(x -> clamp(x * 2, low, high)) for i in 1:N_ENV
+        env -> ActionTransformedEnv(env, action_mapping = x -> clamp(x * 2, low, high)) for i in 1:N_ENV
     ])
 
     init = glorot_uniform(rng)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ end
                     mean(Iterators.flatten(res.hook[1].rewards))
             end
 
-            for method in (:DDPG, :SAC, :TD3)
+            for method in (:DDPG, :SAC, :TD3, :PPO)
                 res = run(
                     Experiment(
                         Val(:JuliaRL),


### PR DESCRIPTION
The PPO Pendulum example had problem with both `action_space` name conflict and `ActionTransformedEnv` being called using an old API. This seems to not have been noticed since this example was not included in tests.

Variable name changed and a slightly ugly workaround for the wrapper added. Also added test for this env.

Not sure if the old version of the wrapper is wanted to allow smooth chaining? Think it would be something like
```julia
ActionTranformedEnv(; action_mapping=identity, action_space_mapping=identity) = env -> ActionTransformedEnv(env, action_mapping, action_space_mapping)
```