### PR TITLE
Fix bug in multi action ppo

### DIFF
--- a/src/algorithms/policy_gradient/ppo.jl
+++ b/src/algorithms/policy_gradient/ppo.jl
@@ -267,11 +267,11 @@ function _update!(p::PPOPolicy, t::AbstractTrajectory)
                 if AC.actor isa GaussianNetwork
                     μ, σ = AC.actor(s)
                     if ndims(a) == 2
-                        log_p′ₐ = sum(normlogpdf(μ, σ, a), dims = 1)
+                        log_p′ₐ = vec(sum(normlogpdf(μ, σ, a), dims = 1))
                     else
                         log_p′ₐ = normlogpdf(μ, σ, a)
                     end
-                    entropy_loss = mean((log(2.0f0π) + 1) / 2 .+ sum(log.(σ), dims = 1))
+                    entropy_loss = mean(size(σ, 1) * (log(2.0f0π) + 1) .+ sum(log.(σ), dims = 1)) / 2
                 else
                     # actor is assumed to return discrete logits
                     logit′ = AC.actor(s)
@@ -280,7 +280,6 @@ function _update!(p::PPOPolicy, t::AbstractTrajectory)
                     log_p′ₐ = log_p′[CartesianIndex.(a, 1:length(a))]
                     entropy_loss = -sum(p′ .* log_p′) * 1 // size(p′, 2)
                 end
-
                 ratio = exp.(log_p′ₐ .- log_p)
                 surr1 = ratio .* adv
                 surr2 = clamp.(ratio, 1.0f0 - clip_range, 1.0f0 + clip_range) .* adv

--- a/src/algorithms/policy_gradient/ppo.jl
+++ b/src/algorithms/policy_gradient/ppo.jl
@@ -271,7 +271,7 @@ function _update!(p::PPOPolicy, t::AbstractTrajectory)
                     else
                         log_p′ₐ = normlogpdf(μ, σ, a)
                     end
-                    entropy_loss = mean(size(σ, 1) * (log(2.0f0π) + 1) .+ sum(log.(σ), dims = 1)) / 2
+                    entropy_loss = mean(size(σ, 1) * (log(2.0f0π) + 1) .+ sum(log, σ; dims = 1)) / 2
                 else
                     # actor is assumed to return discrete logits
                     logit′ = AC.actor(s)


### PR DESCRIPTION
As mentioned in JuliaReinforcementLearning/ReinforcementLearning.jl#234 we had some strange behaviour. This was from the log_p\`_a having a different size than log_p, (1, N) compared to (N,), creating a matrix for the ratio which was then reduced down.

I also found that the entropy loss was not defined to work with multi dimensional actions correctly, it was missing a multiple of how many dimensions there were in the actions space. Then it was also missing a division by 2 in one of the terms compared to how the entropy is defined on https://en.wikipedia.org/wiki/Multivariate_normal_distribution#Differential_entropy