### PR TITLE
Fix SAC Pendulum example

### DIFF
--- a/src/experiments/rl_envs/JuliaRL_SAC_Pendulum.jl
+++ b/src/experiments/rl_envs/JuliaRL_SAC_Pendulum.jl
@@ -30,7 +30,7 @@ function RLCore.Experiment(
             Chain(Dense(ns, 30, relu), Dense(30, 30, relu)),
             Chain(Dense(30, 1, initW = init)),
             Chain(
-                Dense(30, 1, x -> min(max(x, typeof(x)(-20)), typeof(x)(2)), initW = init),
+                Dense(30, 1, x -> clamp(x, typeof(x)(-2), typeof(x)(2)), initW = init),
             ),
         ),
         optimizer = ADAM(0.003),


### PR DESCRIPTION
Lower limit was wrong, -20 instead of -2, and I replaced `min(max(x, ...` with `clamp(x, ...)`