### PR TITLE
Fix GaussianNetwork stddev and replace SACPolicyNetwork

### DIFF
--- a/src/algorithms/policy_gradient/ppo.jl
+++ b/src/algorithms/policy_gradient/ppo.jl
@@ -264,13 +264,13 @@ function _update!(p::PPOPolicy, t::AbstractTrajectory)
             gs = gradient(ps) do
                 v′ = AC.critic(s) |> vec
                 if AC.actor isa GaussianNetwork
-                    μ, σ = AC.actor(s)
+                    μ, logσ = AC.actor(s)
                     if ndims(a) == 2
-                        log_p′ₐ = vec(sum(normlogpdf(μ, σ, a), dims = 1))
+                        log_p′ₐ = vec(sum(normlogpdf(μ, exp.(logσ), a), dims = 1))
                     else
-                        log_p′ₐ = normlogpdf(μ, σ, a)
+                        log_p′ₐ = normlogpdf(μ, exp.(logσ), a)
                     end
-                    entropy_loss = mean(size(σ, 1) * (log(2.0f0π) + 1) .+ sum(log, σ; dims = 1)) / 2
+                    entropy_loss = mean(size(logσ, 1) * (log(2.0f0π) + 1) .+ sum(logσ; dims = 1)) / 2
                 else
                     # actor is assumed to return discrete logits
                     logit′ = AC.actor(s)

--- a/src/algorithms/policy_gradient/ppo.jl
+++ b/src/algorithms/policy_gradient/ppo.jl
@@ -148,9 +148,8 @@ function RLBase.prob(
     if p.update_step < p.n_random_start
         @error "todo"
     else
-        p.approximator.actor(send_to_device(device(p.approximator), state)) |>
-        send_to_host |>
-        StructArray{Normal}
+        μ, logσ = p.approximator.actor(send_to_device(device(p.approximator), state)) |> send_to_host 
+        StructArray{Normal}((μ, exp.(logσ)))
     end
 end
 

--- a/src/algorithms/policy_gradient/sac.jl
+++ b/src/algorithms/policy_gradient/sac.jl
@@ -134,7 +134,6 @@ end
 
 function RLBase.update!(p::SACPolicy, batch::NamedTuple{SARTS})
     s, a, r, t, s′ = send_to_device(device(p.qnetwork1), batch)
-    @show size(s) size(a) size(r)
 
     γ, ρ, α = p.γ, p.ρ, p.α
 
@@ -146,12 +145,10 @@ function RLBase.update!(p::SACPolicy, batch::NamedTuple{SARTS})
     q′ = min.(p.target_qnetwork1(q′_input), p.target_qnetwork2(q′_input))
 
     y = r .+ γ .* (1 .- t) .* vec((q′ .- α .* log_π))
-    @show size(a′) size(q′_input) size(q′) size(y)
 
     # Train Q Networks
     a = Flux.unsqueeze(a, 1)
     q_input = vcat(s, a)
-    @show a q_input
 
     q_grad_1 = gradient(Flux.params(p.qnetwork1)) do
         q1 = p.qnetwork1(q_input) |> vec

--- a/src/algorithms/policy_gradient/sac.jl
+++ b/src/algorithms/policy_gradient/sac.jl
@@ -112,8 +112,8 @@ end
 This function is compatible with a multidimensional action space.
 """
 function evaluate(p::SACPolicy, state)
-    μ, σ = p.policy(state)
-    π_dist = Normal.(μ, σ)
+    μ, logσ = p.policy(state)
+    π_dist = StructArray{Normal}((μ, exp.(logσ)))
     z = rand.(p.rng, π_dist)
     logp_π = sum(logpdf.(π_dist, z), dims = 1)
     logp_π -= sum((2.0f0 .* (log(2.0f0) .- z - softplus.(-2.0f0 * z))), dims = 1)

--- a/src/algorithms/policy_gradient/sac.jl
+++ b/src/algorithms/policy_gradient/sac.jl
@@ -47,7 +47,7 @@ end
 - `rng = Random.GLOBAL_RNG`,
 
 `policy` is expected to output a tuple `(μ, logσ)` of mean and
-standard deviations for the desired action distributions, this
+log standard deviations for the desired action distributions, this
 can be implemented using a `GaussianNetwork` in a `NeuralNetworkApproximator`.
 """
 function SACPolicy(;

--- a/src/algorithms/policy_gradient/sac.jl
+++ b/src/algorithms/policy_gradient/sac.jl
@@ -113,7 +113,7 @@ This function is compatible with a multidimensional action space.
 """
 function evaluate(p::SACPolicy, state)
     μ, logσ = p.policy(state)
-    π_dist = StructArray{Normal}((μ, exp.(logσ)))
+    π_dist = Normal.(μ, exp.(logσ))
     z = rand.(p.rng, π_dist)
     logp_π = sum(logpdf.(π_dist, z), dims = 1)
     logp_π -= sum((2.0f0 .* (log(2.0f0) .- z - softplus.(-2.0f0 * z))), dims = 1)

--- a/src/algorithms/policy_gradient/vpg.jl
+++ b/src/algorithms/policy_gradient/vpg.jl
@@ -1,21 +1,23 @@
 export VPGPolicy, GaussianNetwork
 
 """
-    GaussianNetwork(;pre=identity, μ, σ)
+    GaussianNetwork(;pre=identity, μ, logσ)
 
-`σ` should return the log of std, `exp` will be applied to it automatically.
+Returns `μ` and `logσ` when called. 
+Create a distribution to sample from 
+using `Normal.(μ, exp.(logσ))`.
 """
 Base.@kwdef struct GaussianNetwork{P,U,S}
     pre::P = identity
     μ::U
-    σ::S
+    logσ::S
 end
 
 Flux.@functor GaussianNetwork
 
 function (m::GaussianNetwork)(S)
     x = m.pre(S)
-    m.μ(x), m.σ(x) .|> exp
+    m.μ(x), m.logσ(x) 
 end
 
 """

--- a/src/experiments/rl_envs/JuliaRL_PPO_Pendulum.jl
+++ b/src/experiments/rl_envs/JuliaRL_PPO_Pendulum.jl
@@ -37,7 +37,7 @@ function RLCore.Experiment(
                         Dense(64, 64, relu; initW = glorot_uniform(rng)),
                     ),
                     μ = Chain(Dense(64, 1, tanh; initW = glorot_uniform(rng)), vec),
-                    σ = Chain(Dense(64, 1; initW = glorot_uniform(rng)), vec),
+                    logσ = Chain(Dense(64, 1; initW = glorot_uniform(rng)), vec),
                 ),
                 critic = Chain(
                     Dense(ns, 64, relu; initW = glorot_uniform(rng)),

--- a/src/experiments/rl_envs/JuliaRL_SAC_Pendulum.jl
+++ b/src/experiments/rl_envs/JuliaRL_SAC_Pendulum.jl
@@ -26,12 +26,13 @@ function RLCore.Experiment(
     init = glorot_uniform(rng)
 
     create_policy_net() = NeuralNetworkApproximator(
-        model = SACPolicyNetwork(
-            Chain(Dense(ns, 30, relu), Dense(30, 30, relu)),
-            Chain(Dense(30, 1, initW = init)),
-            Chain(
-                Dense(30, 1, x -> clamp(x, typeof(x)(-2), typeof(x)(2)), initW = init),
+        model = GaussianNetwork(
+            pre = Chain(
+                Dense(ns, 30, relu), 
+                Dense(30, 30, relu)
             ),
+            μ = Chain(Dense(30, na, initW = init)),
+            logσ = Chain(Dense(30, na, x -> clamp.(x, typeof(x)(-10), typeof(x)(2)), initW = init)),
         ),
         optimizer = ADAM(0.003),
     )

--- a/src/experiments/rl_envs/JuliaRL_SAC_Pendulum.jl
+++ b/src/experiments/rl_envs/JuliaRL_SAC_Pendulum.jl
@@ -29,10 +29,10 @@ function RLCore.Experiment(
         model = GaussianNetwork(
             pre = Chain(
                 Dense(ns, 30, relu), 
-                Dense(30, 30, relu)
+                Dense(30, 30, relu),
             ),
-            μ = Chain(Dense(30, na, initW = init)),
-            logσ = Chain(Dense(30, na, x -> clamp.(x, typeof(x)(-10), typeof(x)(2)), initW = init)),
+            μ = Chain(Dense(30, 1, initW = init)),
+            logσ = Chain(Dense(30, 1, x -> clamp.(x, typeof(x)(-10), typeof(x)(2)), initW = init)),
         ),
         optimizer = ADAM(0.003),
     )


### PR DESCRIPTION
As discussed in JuliaReinforcementLearning/ReinforcementLearning.jl#236 I change the value of `sigma` in `GaussianNetwork` to be `log_sigma` to make it clearer to the user how it should be used. I also replace `SACPolicyNetwork` with `GaussianNetwork` since they were already pretty much the same implementation.